### PR TITLE
Filter by both raw_filter and filters simultaneously

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,3 +18,10 @@ Contact
 -------
 * `Follow me on twitter for updates <http://twitter.com/numan856>`_
 
+Changelog
+---------
+
+- **0.2.4**
+
+  - Getting an activity from the riak backend now respects both the raw
+    filter as well as a dict of filters simultaneously.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -437,7 +437,7 @@ class TestRiakBackend(object):
         eq_(activities[0]['id'], activity_1['id'])
         eq_(activities[1]['id'], activity_2['id'])
 
-    def test__get_many_activities_with_raw_filter_and_other_filter_only_runs_raw(self):
+    def test__get_many_activities_with_raw_filter_and_other_filter_runs_both_filters(self):
         self._backend._activities.get('1').delete()
         self._backend._activities.get('2').delete()
         self._backend._activities.get('3').delete()
@@ -464,11 +464,10 @@ class TestRiakBackend(object):
 
         activities = self._backend._get_many_activities(
             activity_ids=['1', '2', '3', '4', '5'], raw_filter=raw_filter,
-            filters={'verb': ['type3'], 'actor': ['1237', '1238']})
+            filters={'actor': ['1234', '1238']})
 
-        eq_(2, len(activities))
+        eq_(1, len(activities))
         eq_(activities[0]['id'], activity_1['id'])
-        eq_(activities[1]['id'], activity_2['id'])
 
     def test_dehydrate_activities(self):
         actor_id = '1234'


### PR DESCRIPTION
It only makes sense to be able to combine a raw filter and a dict of filters, so that you can first filter by the one and then by the other. We only need to pay attention to not filter by an empty dict because no filters would match and all activities would be removed from the result set.
