### PR TITLE
Allow specifying 'published' time for subactivities

### DIFF
--- a/sunspear/activitystreams/models.py
+++ b/sunspear/activitystreams/models.py
@@ -157,8 +157,11 @@ class Activity(Model):
         return model_dict
 
     def get_parsed_sub_activity_dict(self, actor, content="", verb="reply", object_type="reply", \
-        collection="replies", activity_class=None, extra={}, **kwargs):
+        collection="replies", activity_class=None, extra={}, published=None, **kwargs):
         #TODO: Doesn't feel like this should be here Feels like it belongs in the backend.
+
+        if published is None:
+            published = datetime.datetime.utcnow()
 
         in_reply_to_dict = {
             'objectType': 'activity',
@@ -169,7 +172,7 @@ class Activity(Model):
         reply_obj = {
             'objectType': object_type,
             'id': self.get_new_id(),
-            'published': datetime.datetime.utcnow(),
+            'published': published,
             'content': content,
             'inReplyTo': [in_reply_to_dict],
         }
@@ -177,7 +180,8 @@ class Activity(Model):
         reply_dict = {
             'actor': actor,
             'object': reply_obj,
-            'verb': verb
+            'verb': verb,
+            'published': published,
         }
 
         if isinstance(content, dict):
@@ -193,7 +197,7 @@ class Activity(Model):
             # 'actor': _activity_data['actor'],
             'verb': verb,
             # 'id': _activity_data['id'],
-            # 'published': _activity_data['published'],
+            'published': published,
             'object': {
                 'objectType': 'activity',
                 # 'id': _activity_data['id'],

--- a/sunspear/backends/riak.py
+++ b/sunspear/backends/riak.py
@@ -384,7 +384,7 @@ class RiakBackend(BaseBackend):
 
     def sub_activity_create(
         self, activity, actor, content, extra={}, sub_activity_verb="",
-            **kwargs):
+            published=None, **kwargs):
         sub_activity_model = SUB_ACTIVITY_MAP[sub_activity_verb.lower()][0]
         sub_activity_attribute = SUB_ACTIVITY_MAP[sub_activity_verb.lower()][1]
         object_type = kwargs.get('object_type', sub_activity_verb)
@@ -396,7 +396,7 @@ class RiakBackend(BaseBackend):
             .get_parsed_sub_activity_dict(
                 actor=actor, content=content, verb=sub_activity_verb,
                 object_type=object_type, collection=sub_activity_attribute,
-                activity_class=sub_activity_model, extra=extra)
+                activity_class=sub_activity_model, published=published, extra=extra)
 
         sub_activity_obj = self.create_activity(sub_activity_obj, activity_id=original_activity_obj['id'])
 


### PR DESCRIPTION
This allows explicitly setting the "published" time, e.g. to have deterministic tests.
