### PR TITLE
Upgrade riak dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     test_suite='nose.collector',
     install_requires=[
-        'riak==2.2.0',
+        'riak==2.5.4',
         'python-dateutil==1.5',
         'protobuf==2.6.1',
     ],


### PR DESCRIPTION
Upgrading riak from 2.2.0 to 2.5.4

Release notes: https://github.com/basho/riak-python-client/blob/master/RELNOTES.md

As far as I can tell, the only potentially backwards-incompatible change is:

> NOTE: for Riak TS data, automatic conversion from epoch values to Python datetime objects has been removed. If you would like to have automatic conversion, use RiakClient(transport_options={'ts_convert_timestamp': True})

But I don't think you're using that, are you?
