### PR TITLE
Updates python dateutil install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     test_suite='nose.collector',
     install_requires=[
         'riak==2.5.4',
-        'python-dateutil==1.5',
+        'python-dateutil>=1.5, != 2.0',
         'protobuf==2.6.1',
         'sqlalchemy==1.1.14',
         'MySQL-python==1.2.5',


### PR DESCRIPTION
A few packages demand newer versions of python-dateutil, notably boto3. It would be nice to be able to update this.

According to https://github.com/dateutil/dateutil/blob/master/NEWS only version 2.1 should be backwards incompatible with Python2. 